### PR TITLE
Add support for hosts

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 		"ssh":             handleArray(),
 		"tagOwners":       handleObject(),
 		"tests":           handleArray(),
+		"hosts":           handleObject(),
 	}
 )
 


### PR DESCRIPTION
Currently having a hosts section in the parent policy works fine. But using hosts in a child results in a segfault. This defines hosts as being merged as an object.